### PR TITLE
for Raspberry Pi

### DIFF
--- a/bin/node-build
+++ b/bin/node-build
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-NODE_BUILD_VERSION="20130620"
+NODE_BUILD_VERSION="20140629"
 
 set -E
 exec 3<&2 # preserve original stderr at fd 3
@@ -475,6 +475,10 @@ install_node() {
   case "$uname" in
     *x86_64*) arch=x64 ;;
     *i*86*) arch=x86 ;;
+  esac
+
+  case "$arch" in
+    armv6l) arch=arm-pi ;;
   esac
 
   nobinary=0


### PR DESCRIPTION
Raspberry Pi用標準ディストリビューションのRaspbian(Wheezy)では、`arch`が armv6l として
取得されますが、node.js サイトでは http://nodejs.org/dist/v0.10.26/node-v0.10.26-linux-arm-pi.tar.gz
となっていて、現在の`node-build`ではtarファイルが取得できないため、アーキテクチャの読み替
えを追加しました。マージの検討をお願いします。
