### PR TITLE
Add --skip-existing option to `ndenv install`.

### DIFF
--- a/bin/ndenv-install
+++ b/bin/ndenv-install
@@ -6,11 +6,12 @@
 #        ndenv install [-f|--force] [-k|--keep] [-v|--verbose] <definition-file>
 #        ndenv install -l|--list
 #
-#   -l/--list        List all available versions
-#   -f/--force       Install even if the version appears to be installed already
-#   -k/--keep        Keep source tree in $NDENV_BUILD_ROOT after installation
-#                    (defaults to $NDENV_ROOT/sources)
-#   -v/--verbose     Verbose mode: print compilation status to stdout
+#   -l/--list          List all available versions
+#   -f/--force         Install even if the version appears to be installed already
+#   -k/--keep          Keep source tree in $NDENV_BUILD_ROOT after installation
+#                      (defaults to $NDENV_ROOT/sources)
+#   -v/--verbose       Verbose mode: print compilation status to stdout
+#   -s/--skip-existing Skip if the version appears to be installed already
 #
 # For detailed information on installing Node versions with
 # node-build, including a list of environment variables for adjusting
@@ -63,6 +64,9 @@ for option in "${OPTIONS[@]}"; do
     ;;
   "f" | "force" )
     FORCE=true
+    ;;
+  "s" | "skip-existing" )
+    SKIP_EXISTING=true
     ;;
   "k" | "keep" )
     [ -n "${NDENV_BUILD_ROOT}" ] || NDENV_BUILD_ROOT="${NDENV_ROOT}/sources"
@@ -121,6 +125,10 @@ PREFIX="${NDENV_ROOT}/versions/${VERSION_NAME}"
 # If the installation prefix exists, prompt for confirmation unless
 # the --force option was specified.
 if [ -z "$FORCE" ] && [ -d "${PREFIX}/bin" ]; then
+  if [ "$SKIP_EXISTING" = true ] ; then
+    exit 1
+  fi
+
   echo "ndenv: $PREFIX already exists" >&2
   read -p "continue with installation? (y/N) "
 


### PR DESCRIPTION
Currently, I use this command to install the latest `node` version.
`% ndenv install $(ndenv install -l | grep -v - | tail -1)`

It works good. but I get this message if the current version is the latest one.
```
ndenv: /Users/mshibanami/.anyenv/envs/ndenv/versions/v4.2.1 already exists
continue with installation? (y/N)
```
It's a bit annoying.

`rbenv` solves the same issue with `--skip-exisiting` option.
So I also need it for `ndenv install`.