### PR TITLE
use `ndenv root` command to installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Almost all of code come from [ruby-build](https://github.com/sstephenson/ruby-bu
 
 ## INSTALL
 
-    $ git clone https://github.com/riywo/node-build.git ~/.ndenv/plugins/node-build
+    $ git clone https://github.com/riywo/node-build.git $(ndenv root)/plugins/node-build
 
 node-build currently supports only download a compiled tarball.
 Both [node.js](http://nodejs.org/) and [io.js](https://iojs.org) are supported.


### PR DESCRIPTION
I use `ndenv` on _your_ `anyenv`. `anyenv` installs `**env` to different directory.

So, this pull-request makes same way to install `ndenv` for both original installation and installation via `anyenv`.
